### PR TITLE
docs: add archive notice with link to websites-monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **⚠️ This repository has been archived.** Development has moved to the [websites-monorepo](https://github.com/taearls/websites-monorepo). The Cuckoo and the Birds app lives at [`apps/cuckoo/`](https://github.com/taearls/websites-monorepo/tree/main/apps/cuckoo) in the monorepo.
+
+---
+
 # Cuckoo and the Birds
 
 Cuckoo and the Birds is a Chicago rock band who play sad songs that flirt with harmonies. For booking inquiries, please contact [cuckooandthebirds@gmail.com](mailto:cuckooandthebirds@gmail.com).


### PR DESCRIPTION
## Summary

- Adds an archive notice at the top of README.md directing users to the [websites-monorepo](https://github.com/taearls/websites-monorepo)
- Links directly to [`apps/cuckoo/`](https://github.com/taearls/websites-monorepo/tree/main/apps/cuckoo) in the monorepo

This is part of [taearls/websites-monorepo#12](https://github.com/taearls/websites-monorepo/issues/12) — archiving the original repositories after migrating to the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)